### PR TITLE
PIC-4510: First smoke test scenario

### DIFF
--- a/data/courtHearingRequest/courtHearingRequestGenerator.test.ts
+++ b/data/courtHearingRequest/courtHearingRequestGenerator.test.ts
@@ -184,7 +184,7 @@ test.describe('Court Hearing Request Generator', async () => {
             const randomDate = faker.date.past()
             Object.keys(hearingSessionTimes).forEach((sessionKey: keyof HearingSessionTimes) => {
                 test(`- ${sessionKey}`, async () => {
-                    const expectedSitting = `${moment(randomDate).format('YYYY-MM-DD')}T${hearingSessionTimes[sessionKey].toString().padStart(2, '0')}:00:00.000Z`
+                    const expectedSitting = `${moment(randomDate).utc().format('YYYY-MM-DD')}T${hearingSessionTimes[sessionKey].toString().padStart(2, '0')}:00:00.000Z`
                     const result = sut.generate({ hearingDay: { hearingDate: randomDate, hearingSession: sessionKey }})
 
                     testForExpectedSitting(result, expectedSitting)

--- a/steps/pages/cases/cases.ts
+++ b/steps/pages/cases/cases.ts
@@ -1,16 +1,30 @@
-import { Page } from "@playwright/test"
+import { expect, Page } from "@playwright/test"
 import { getTestConfig } from "@utils/config/testConfig"
 
 const config = getTestConfig()
 
+const casesForCourt = async (page: Page, courtCode: string, date?: string) => {
+    if(date) {
+        expect(date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    }
+    await page.goto(`${config.services.prepareACase.urls.root}/${courtCode}/cases${date ? `/${date}` : ''}`)
+}
 const caseSummary = async (page: Page, courtCode: string, hearingId: string, defendantId: string) => {
     await page.goto(`${config.services.prepareACase.urls.root}/${courtCode}/hearing/${hearingId}/defendant/${defendantId}/summary`)
 }
 
+const ensureDefendentExists = async (page: Page, defendantName: string) => {
+    const defendantRow = page.getByRole('row', { exact: false, name: defendantName })
+    expect(defendantRow).toBeVisible()
+    return defendantRow
+}
+
 const cases = {
     pages: {
+        casesForCourt,
         caseSummary
-    }
+    },
+    ensureDefendentExists
 }
 
 export default cases

--- a/tests/tags.ts
+++ b/tests/tags.ts
@@ -1,0 +1,5 @@
+export const TAGS = {
+    regression: '@Regression',
+    smoke: '@Smoke',
+    ui: '@UI',
+}


### PR DESCRIPTION
First smoke test, developing our initial test to specifically confirm that user appears in today case list.
This takes the generated user that is added through the Court Hearing Event Reciever and ensure that it is in the cases list for the day it was generated against (in this case, the "today" date).

One thing of note for going forward, the order we receive case data means that the new entry appears at the end of the list, if we expand to multiple tests, or test runs cumulative add more than a page's worth of data then the result would be expected to appear on the second page, but this cannot be determined from the data in the current scope alone.

I don't know if we have the scope to solve for this problem that isn't happening so far as we blatantly aren't adding anywhere near enough data but worth people knowing this going forward as we likely move ever closer to having enough tests that we do.