### PR TITLE
e2e test framework: preset courts and page aware tests for cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ AUTH_URL = "https://sign-in-dev.hmpps.service.justice.gov.uk/auth/sign-in?redire
 
 COURT_HEARING_EVENT_RECEIVER_URL = "https://court-hearing-event-receiver-dev.hmpps.service.justice.gov.uk" 
 COURT_HEARING_EVENT_RECEIVER_ADD = "{rootUrl}/hearing/{id}"
+COURT_HEARING_EVENT_RECEIVER_WAIT_MILLISECONDS = "200"
 
 PREPARE_A_CASE_FOR_SENTENCE_URL = "https://prepare-a-case-dev.apps.live-1.cloud-platform.service.justice.gov.uk"
 ```

--- a/data/courtHearingRequest/courtCentres.data.ts
+++ b/data/courtHearingRequest/courtCentres.data.ts
@@ -10,3 +10,11 @@ export const courtCentres: CourtCentreData[] = [
     Coventry,
     Sheffield
 ]
+
+/**
+ * Utilised by tests/e2e/setup/default to set the default courts for the user
+ * Once a court is added it cannot be added again as it is removed from the options to add
+ * For the time being, this is all Courts as we have so few in scope but could deviate as courtCentres grows
+ */
+
+export const defaultCourtCentres: CourtCentreData[] = courtCentres

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
             "license": "MIT",
             "dependencies": {
                 "faker": "^5.5.3",
-                "moment": "^2.30.1"
+                "moment": "^2.30.1",
+                "node": "23.5"
             },
             "devDependencies": {
                 "@faker-js/faker": "^9.4.0",
@@ -1840,6 +1841,28 @@
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
+        },
+        "node_modules/node": {
+            "version": "23.5.0",
+            "resolved": "https://registry.npmjs.org/node/-/node-23.5.0.tgz",
+            "integrity": "sha512-Wco8qYfFUAotVJJoMbB30cYdPbTqFd9QtzC528GvTCYWMldnPUu1pLNz4sKNKxal+dgBuAyUu8tRkeLVx1VT8Q==",
+            "hasInstallScript": true,
+            "license": "ISC",
+            "dependencies": {
+                "node-bin-setup": "^1.0.0"
+            },
+            "bin": {
+                "node": "bin/node"
+            },
+            "engines": {
+                "npm": ">=5.0.0"
+            }
+        },
+        "node_modules/node-bin-setup": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.3.tgz",
+            "integrity": "sha512-opgw9iSCAzT2+6wJOETCpeRYAQxSopqQ2z+N6BXwIMsQQ7Zj5M8MaafQY8JMlolRR6R1UXg2WmhKp0p9lSOivg==",
+            "license": "ISC"
         },
         "node_modules/node-fetch": {
             "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     },
     "dependencies": {
         "faker": "^5.5.3",
-        "moment": "^2.30.1"
+        "moment": "^2.30.1",
+        "node": "23.5"
     }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -45,14 +45,18 @@ const config: PlaywrightTestConfig = {
             testMatch: 'tests/config/**/*.setup.ts'
         },
         {
+            name: 'auth',
+            testMatch: 'tests/auth/**/*.setup.ts'
+        },
+        {
             name: 'setup',
             testMatch: 'tests/setup/**/*.setup.ts',
-            dependencies: ['config']
+            dependencies: ['auth', 'config']
         },
         {
             name: 'e2e',
             testMatch: 'tests/**/*.spec.ts',
-            dependencies: ['setup', 'data unit tests'],
+            dependencies: ['auth', 'config', 'setup', 'data unit tests'],
             use: {
                 storageState: STORAGE_STATE
             }

--- a/steps/_data/data.ts
+++ b/steps/_data/data.ts
@@ -1,11 +1,11 @@
 import { CourtHearingRequest } from "@data/courtHearingRequest/courtHearingRequest";
-import { APIRequestContext, expect } from "@playwright/test";
+import { APIRequestContext, expect, Page } from "@playwright/test";
 import { includeSlug } from "@utils/config/configUtils";
 import { getTestConfig } from "@utils/config/testConfig";
 
 const config = getTestConfig()
 
-export const sendCourtHearingToEventReceiver = async (requestContext: APIRequestContext, courtHearingRequest: CourtHearingRequest) => {
+export const sendCourtHearingToEventReceiver = async (page: Page, requestContext: APIRequestContext, courtHearingRequest: CourtHearingRequest) => {
     const response = await requestContext.post(includeSlug(config.services.courtHearingEventReceiver.urls.addHearing, courtHearingRequest.hearing.id, "id"),
     {
         headers: { "Authorization" : `Bearer ${config.auth.token}`},
@@ -13,4 +13,6 @@ export const sendCourtHearingToEventReceiver = async (requestContext: APIRequest
     })
 
     expect(response.status()).toEqual(200)
+
+    await page.waitForTimeout(config.services.courtHearingEventReceiver.waitTime)
 }

--- a/steps/elements/headings.ts
+++ b/steps/elements/headings.ts
@@ -1,0 +1,13 @@
+import { expect, Page } from "@playwright/test"
+
+const exists = async (page: Page, level: number, text?: string) => {
+    const options = {
+        level,
+        ...(text ? { name: text } : {})
+    }
+    await expect(page.getByRole('heading', options)).toBeVisible()
+}
+
+export default {
+    exists
+}

--- a/steps/elements/links.ts
+++ b/steps/elements/links.ts
@@ -1,0 +1,11 @@
+import { expect, Page } from "@playwright/test"
+
+const govukLinkExists = async (page: Page, linkText: string) => {
+    const link = page.getByRole('link', { name: linkText })
+    await expect(link).toHaveClass(/govuk-link/)
+    await expect(link).toBeVisible()
+}
+
+export default {
+    govukLinkExists
+}

--- a/steps/pages/courts/manageCourts.ts
+++ b/steps/pages/courts/manageCourts.ts
@@ -1,5 +1,7 @@
 import { expect, Page } from '@playwright/test'
 import { getTestConfig } from '@utils/config/testConfig'
+import headings from '@steps/elements/headings'
+import links from '@steps/elements/links'
 
 const config = getTestConfig()
 
@@ -10,18 +12,26 @@ const editCourts = async (page: Page) => {
     await page.goto(`${config.services.prepareACase.urls.root}/my-courts/edit`)
 }
 
-const addCourtToUser = async (page: Page, court: string) => {
+const addCourtToUser = async (page: Page, courtName: string) => {
+    await addCourtsToUser(page, [courtName])
+}
+
+const addCourtsToUser = async (page: Page, courtsNames: string[]) => {
     await editCourts(page)
     
-    await page.getByRole('button', { name: /Accept analytics cookies/ }).click()
-    await page.focus('#pac-select-court')
-    await page.keyboard.type(court)
-    await page.keyboard.press('Enter')
-    await page.getByRole('button', { name: 'Add' }).click()
-    await page.locator('[href="?save=true"]', { hasText: 'Save  and continue' }).click()
-    await expect(page).toHaveTitle('My courts - Prepare a case for sentence')
-    await page.getByRole('link', { name: court }).click()
-    await expect(page).toHaveTitle('Case list - Prepare a case for sentence')
+    for(const name of courtsNames) {
+        await page.getByRole('combobox').fill(name)
+        await page.keyboard.press('Enter')
+        await page.getByRole('button', { name: 'Add' }).click()
+    }
+    await page.getByRole('button', { name: 'Save list and continue' }).click()
+}
+
+const verifyUserCourts = async (page: Page, courtNames: string[]) => {
+    await headings.exists(page, 1, 'My courts')
+    for(const name of courtNames) {
+        await links.govukLinkExists(page, name)
+    }
 }
 
 const manageCourts = {
@@ -29,7 +39,9 @@ const manageCourts = {
         myCourts,
         editCourts
     },
-    addCourtToUser
+    addCourtToUser,
+    addCourtsToUser,
+    verifyUserCourts
 }
 
 export default manageCourts

--- a/tests/auth/auth.setup.ts
+++ b/tests/auth/auth.setup.ts
@@ -3,7 +3,7 @@ import { STORAGE_STATE } from 'playwright.config'
 import { getTestConfig } from '@utils/config/testConfig'
 
 // TODO Can we have a better assertion than the expected title, like identifiying some "is logged in state" on the page
-setup('Authenticate', async ({page}) => {
+setup('Authenticate', async ({ page }) => {
     console.debug('Authenticating test suite')
 
     const config = getTestConfig()

--- a/tests/config/config.setup.ts
+++ b/tests/config/config.setup.ts
@@ -20,7 +20,8 @@ setup('Config setup', async ({page}) => {
           urls: {
             root: courtHearingEventReceiverRootUrl,
             addHearing: includeSlug(process.env.COURT_HEARING_EVENT_RECEIVER_ADD, courtHearingEventReceiverRootUrl)
-          }
+          },
+          waitTime: Number(process.env.COURT_HEARING_EVENT_RECEIVER_WAIT_MILLISECONDS)
         },
         prepareACase: {
           urls: {

--- a/tests/e2e/cases/add-case-defendant-and-confirm.spec.ts
+++ b/tests/e2e/cases/add-case-defendant-and-confirm.spec.ts
@@ -11,20 +11,18 @@ const courtHearingGen = courtHearingGenerator()
 
 test.describe('WHEN a Case and Defendant is added to the Court Hearing Event Receiver', async () => {
     test('THEN the same Defendant can be found in Prepare A Case', { tag: [TAGS.ui, TAGS.regression, TAGS.smoke] }, async ({ page, request }) => {
-        /**
-         * The challenge here is that this adds a new result to bottom of the list
-         * This means with enough runs or 
-         */
         const chosenCourt = Sheffield
         const courtHearingRequest = courtHearingGen.generate({ court: chosenCourt })
         const defendant = courtHearingRequest.hearing.prosecutionCases.at(0).defendants.at(0)
         const person = defendant.personDefendant.personDetails
         const fullName = `${person.firstName} ${person.lastName}`
 
-        await sendCourtHearingToEventReceiver(request, courtHearingRequest)
-        await manageCourts.addCourtToUser(page, Sheffield.name)
+        await sendCourtHearingToEventReceiver(page, request, courtHearingRequest)
         
         await cases.pages.casesForCourt(page, chosenCourt.code, moment().format('YYYY-MM-DD'))
-        const defendantRow = await cases.ensureDefendentExists(page, fullName)
+        await cases.pageAwareCheck(page,
+            () => cases.ensureDefendentExists(page, fullName),
+            `Unable to locate and confirm case entry for defendant ${fullName}`
+        )
     })
 })

--- a/tests/e2e/cases/filter-with-current-date-and-verify-defendant-details.spec.ts
+++ b/tests/e2e/cases/filter-with-current-date-and-verify-defendant-details.spec.ts
@@ -4,7 +4,6 @@ import { Sheffield } from "@data/courtHearingRequest/courtCentres.data";
 import { TAGS } from "tests/tags";
 import cases from "@steps/pages/cases/cases";
 import courtHearingGenerator from "@data/courtHearingRequest/courtHearingRequestGenerator";
-import manageCourts from "@steps/pages/courts/manageCourts";
 import moment from "moment";
 import { sendCourtHearingToEventReceiver } from "@steps/_data/data";
 
@@ -18,13 +17,15 @@ test.describe('WHEN a Case and Defendant is added to the Court Hearing Event Rec
         const person = defendant.personDefendant.personDetails
         const fullName = `${person.firstName} ${person.lastName}`
 
-        const offence = courtHearingRequest.hearing.prosecutionCases.at(0).defendants.at(0).offences.at(0).offenceTitle
-        const listing = courtHearingRequest.hearing.prosecutionCases.at(0).defendants.at(0).offences.at(0).listingNumber
-        const court = courtHearingRequest.hearing.courtCentre.roomName
+        const offence = defendant.offences.at(0).offenceTitle
+        const listing = defendant.offences.at(0).listingNumber
+        const courtName = courtHearingRequest.hearing.courtCentre.roomName
 
-        await sendCourtHearingToEventReceiver(request, courtHearingRequest)
-        await manageCourts.addCourtToUser(page, Sheffield.name)
+        await sendCourtHearingToEventReceiver(page, request, courtHearingRequest)
         await cases.pages.casesForCourt(page, chosenCourt.code, moment().format('YYYY-MM-DD'))
-        await cases.verifyDefedantDetails(page, fullName, "No record", offence, listing, 'Morning', court)
+        await cases.pageAwareCheck(page,
+            () => cases.verifyDefedantDetails(page, fullName, "No record", offence, listing, 'Morning', courtName),
+            `Unable to verify details of case entry for ${fullName}`
+        )
     })
 })

--- a/tests/setup/default.setup.ts
+++ b/tests/setup/default.setup.ts
@@ -1,0 +1,11 @@
+import { Coventry, defaultCourtCentres, Sheffield } from '@data/courtHearingRequest/courtCentres.data'
+import { test as setup } from '@playwright/test'
+import manageCourts from '@steps/pages/courts/manageCourts'
+
+setup('Set default user courts', async ({ page }) => {
+    console.debug('Setting default user courts:')
+    console.debug(defaultCourtCentres.reduce((acc, cur, i) => `${acc}${i > 0 ? `, ` : ''}${cur.name} (${cur.code})`, 'Courts to register: '))
+    const courtNames = defaultCourtCentres.map(c => c.name)
+    await manageCourts.addCourtsToUser(page, courtNames)
+    await manageCourts.verifyUserCourts(page, courtNames)
+})

--- a/utils/config/testConfig.d.ts
+++ b/utils/config/testConfig.d.ts
@@ -9,13 +9,13 @@ type TestConfig = {
                 root: string,
                 addHearing: string
             }
+            waitTime: number
         },
         prepareACase: {
             // Example of an internal service, keep to basics and steps can manage specifics
             urls: {
                 auth: string,
-                root: string,
-                // editCourts: string
+                root: string
             }
         }
     }

--- a/utils/textUtils.ts
+++ b/utils/textUtils.ts
@@ -1,0 +1,13 @@
+export const countSuffix = (value: number) => {
+    const lastNumeric = value.toString().at(value.toString().length - 1)
+    switch(lastNumeric) {
+        case '1':
+            return `${value}st`
+        case '2':
+            return `${value}nd`
+        case '3':
+            return `${value}rd`
+        default:
+            return `${value}th`
+    }
+}


### PR DESCRIPTION
Add default courts prior to test suite.
- Adding a court per test won't work without killing the session every time as it is predicated on searching for the court in edit-courts and adding it.
- Rather than a complicated system of traverse and check each time the test required a courts, we have a managed list of courts and add them to the user's session as a dependency to the main test suite.
- The value this list can be managed for create a test scope for courts used in data generation.
- It is worth noting that taking the time to do this per test had the side effect of allowing the CHER time to process a request and removing this step resulted in failures as the generated court hearing was not in the retrieved data before we navigate to the cases page on prepare-a-case. For the moment I have temporarily solved this adding a configurable pause after sending the request to give it time to process (currently set at 200 milliseconds in the ReadMe but this is entirely experiential at this point) as a stop gap measure but this probably needs more thought as this could add up to a lot of dead time as the test suite expands.

Make cases tests search through possible pages.
- Our initial simple tests had begun failing simply because new data can appear on subsequent pages if the data in dev builds up such that we have more than a pages' worth.
- This was solved for a single test as a POC
- This has not been extracted to a generic method that takes a child method it trusts will either fail, pass and return true or not find on the current page and return false.
- If no success is returned by the time the pagination runs out, it will fail the test.